### PR TITLE
Add support for source maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ When creating universal Web apps it's common to build two bundles with Webpack, 
 
 The entry point to the client bundle renders to the DOM, e.g.
 
-```
+```js
 // client.js
 
 import ReactDOM from 'react-dom';
@@ -21,7 +21,7 @@ ReactDOM.render(<App />, document.getElementById('#root'));
 
 And the entry point to the server bundle renders to string, e.g.
 
-```
+```js
 // server.js
 
 import { renderToString } from 'react-dom/server';
@@ -49,7 +49,7 @@ export default function universalRenderer() {
 
 > NOTE: The server bundle is itself middleware allowing you to mount it anywhere in an existing node server, e.g.
 
-```
+```js
 const express = require('express');
 const universalRenderer = require('./dist/server');
 const app = express();
@@ -70,7 +70,7 @@ It turns out hot reloading a Webpack bundle on the server is much easier than on
 
 Webpack Hot Server Middleware expects your Webpack config to export an [array of configurations](http://webpack.github.io/docs/configuration.html#multiple-configurations), one for your client bundle and one for your server bundle, e.g.
 
-```
+```js
 // webpack.config.js
 
 module.exports = [
@@ -93,7 +93,7 @@ module.exports = [
 
 It then needs to be mounted immediately after `webpack-dev-middleware`, e.g.
 
-```
+```js
 const express = require('express');
 const webpack = require('webpack');
 const webpackDevMiddleware = require('webpack-dev-middleware');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-hot-server-middleware",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Hot updates Webpack bundles on the server",
   "main": "src/",
   "scripts": {
@@ -17,7 +17,8 @@
   "license": "MIT",
   "dependencies": {
     "debug": "^2.2.0",
-    "require-from-string": "^1.2.0"
+    "require-from-string": "^1.2.0",
+    "source-map-support": "^0.4.2"
   },
   "peerDependencies": {
     "webpack": "*"

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,10 @@ function getChunkFilename(stats, outputPath, chunkName) {
 
 function installSourceMapSupport(fs) {
     sourceMapSupport.install({
+        // NOTE: If https://github.com/evanw/node-source-map-support/pull/149
+        // lands we can be less aggressive and explicitly invalidate the source
+        // map cache when Webpack recompiles.
+        emptyCacheBetweenOperations: true,
         retrieveSourceMap(source) {
             try {
                 return {

--- a/src/index.js
+++ b/src/index.js
@@ -32,13 +32,6 @@ function getChunkFilename(stats, outputPath, chunkName) {
 
 function installSourceMapSupport(fs) {
     sourceMapSupport.install({
-        retrieveFile(source) {
-            try {
-                return fs.readFileSync(source).toString();
-            } catch(e) {
-                // Doesn't exist
-            }
-        },
         retrieveSourceMap(source) {
             try {
                 return {


### PR DESCRIPTION
Previously stack traces looked like this:

![screen shot 2016-09-27 at 12 10 14](https://cloud.githubusercontent.com/assets/539309/18871053/7d025900-84ab-11e6-8846-500d662e819c.png)

Now they look like this:

![screen shot 2016-09-27 at 12 14 19](https://cloud.githubusercontent.com/assets/539309/18871153/0215bf10-84ac-11e6-9a3b-85832c1bbe21.png)
