### PR TITLE
Add support for inline sourcemaps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,12 +58,9 @@ function installSourceMapSupport(fs) {
         // lands we can be less aggressive and explicitly invalidate the source
         // map cache when Webpack recompiles.
         emptyCacheBetweenOperations: true,
-        retrieveSourceMap(source) {
+        retrieveFile(source) {
             try {
-                return {
-                    url: source,
-                    map: fs.readFileSync(`${source}.map`).toString()
-                };
+                return fs.readFileSync(source, 'utf8');
             } catch(ex) {
                 // Doesn't exist
             }


### PR DESCRIPTION
This PR adds support for inline sourcemaps like `inline-cheap-module-source-map`. Sourcemaps which are seperated into .map files like with `cheap-module-source-map` are still working.

`source-map-support` uses internally `retrieveFile` in `retrieveSourceMap` to resolve files.

Btw the reason why I'm using `inline-cheap-module-source-map` is that this allows me to debug my server-side bundle in IntelliJ :sunglasses: