### PR TITLE
pass server stats to serverRenderer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -115,6 +115,10 @@ function webpackHotServerMiddleware(multiCompiler, options) {
         const filename = getFilename(serverStats, outputPath, options.chunkName);
         const buffer = outputFs.readFileSync(filename);
         try {
+            options.config = {
+                client: serverCompiler.options,
+                server: clientCompiler.options
+            }
             serverRenderer = getServerRenderer(filename, buffer, clientStats, serverStats, options);
         } catch (ex) {
             debug(ex);

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ function getFilename(serverStats, outputPath, chunkName) {
     );
 }
 
-function getServerRenderer(filename, buffer, clientStats) {
+function getServerRenderer(filename, buffer, clientStats, serverStats) {
     const errMessage = `The 'server' compiler must export a function in the form of \`(stats) => (req, res, next) => void 0\``;
 
     let serverRenderer = interopRequireDefault(
@@ -44,7 +44,7 @@ function getServerRenderer(filename, buffer, clientStats) {
         throw new Error(errMessage);
     }
 
-    serverRenderer = serverRenderer(clientStats.toJson());
+    serverRenderer = serverRenderer(clientStats.toJson(), serverStats.toJson());
     if (typeof serverRenderer !== 'function') {
         throw new Error(errMessage);
     }
@@ -115,7 +115,7 @@ function webpackHotServerMiddleware(multiCompiler, options) {
         const filename = getFilename(serverStats, outputPath, options.chunkName);
         const buffer = outputFs.readFileSync(filename);
         try {
-            serverRenderer = getServerRenderer(filename, buffer, clientStats);
+            serverRenderer = getServerRenderer(filename, buffer, clientStats, serverStats);
         } catch (ex) {
             debug(ex);
             error = ex;

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ function getFilename(serverStats, outputPath, chunkName) {
     );
 }
 
-function getServerRenderer(filename, buffer, clientStats, serverStats) {
+function getServerRenderer(filename, buffer, clientStats, serverStats, options) {
     const errMessage = `The 'server' compiler must export a function in the form of \`(stats) => (req, res, next) => void 0\``;
 
     let serverRenderer = interopRequireDefault(
@@ -44,7 +44,7 @@ function getServerRenderer(filename, buffer, clientStats, serverStats) {
         throw new Error(errMessage);
     }
 
-    serverRenderer = serverRenderer(clientStats.toJson(), serverStats.toJson());
+    serverRenderer = serverRenderer(clientStats.toJson(), serverStats.toJson(), options);
     if (typeof serverRenderer !== 'function') {
         throw new Error(errMessage);
     }
@@ -115,7 +115,7 @@ function webpackHotServerMiddleware(multiCompiler, options) {
         const filename = getFilename(serverStats, outputPath, options.chunkName);
         const buffer = outputFs.readFileSync(filename);
         try {
-            serverRenderer = getServerRenderer(filename, buffer, clientStats, serverStats);
+            serverRenderer = getServerRenderer(filename, buffer, clientStats, serverStats, options);
         } catch (ex) {
             debug(ex);
             error = ex;

--- a/src/index.js
+++ b/src/index.js
@@ -116,8 +116,8 @@ function webpackHotServerMiddleware(multiCompiler, options) {
         const buffer = outputFs.readFileSync(filename);
         try {
             options.config = {
-                client: serverCompiler.options,
-                server: clientCompiler.options
+                client: clientCompiler.options,
+                server: serverCompiler.options
             }
             serverRenderer = getServerRenderer(filename, buffer, clientStats, serverStats, options);
         } catch (ex) {


### PR DESCRIPTION
Why? The reason I need this because i'm using server stats to link module IDs to modules within split client chunks. I'm sure there are plenty of reasons others might need this.