### PR TITLE
Add support for multiple clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ module.exports = [
 ];
 ```
 
-> NOTE: It's important both the 'client' and 'server' configs are given the name 'client' and 'server' respectively.
+> NOTE: It's important both the 'client' and 'server' configs are given a name prefixed with 'client' and 'server' respectively.
 
 It then needs to be mounted immediately after `webpack-dev-middleware`, e.g.
 

--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,7 @@ function webpackHotServerMiddleware(multiCompiler, options) {
         throw new Error(`Expected a webpack compiler named 'server'`);
     }
     if (!clientCompilers.length) {
-        throw new Error(`Expected a webpack compiler named 'client'`);
+        throw new Error(`Expected at least one webpack compiler prefixed with 'client'`);
     }
 
     const outputFs = serverCompiler.outputFileSystem;

--- a/test/fixtures/multipleclients/desktop.js
+++ b/test/fixtures/multipleclients/desktop.js
@@ -1,0 +1,1 @@
+'Hello Desktop';

--- a/test/fixtures/multipleclients/mobile.js
+++ b/test/fixtures/multipleclients/mobile.js
@@ -1,0 +1,1 @@
+'Hello Mobile';

--- a/test/fixtures/multipleclients/server.js
+++ b/test/fixtures/multipleclients/server.js
@@ -1,0 +1,1 @@
+module.exports = stats => (req, res, next) => res.json(stats);

--- a/test/fixtures/multipleclients/webpack.config.js
+++ b/test/fixtures/multipleclients/webpack.config.js
@@ -1,0 +1,35 @@
+const path = require('path');
+
+const dist = path.join(__dirname, 'dist');
+
+module.exports = [
+    {
+        name: 'client-mobile',
+        target: 'web',
+        context: __dirname,
+        entry: './mobile',
+        output: {
+            path: dist,
+            filename: 'mobile.js'
+        }
+    }, {
+        name: 'client-desktop',
+        target: 'web',
+        context: __dirname,
+        entry: './desktop',
+        output: {
+            path: dist,
+            filename: 'desktop.js'
+        }
+    }, {
+        name: 'server',
+        target: 'node',
+        context: __dirname,
+        entry: './server',
+        output: {
+            path: dist,
+            filename: 'server.js',
+            libraryTarget: 'commonjs2'
+        }
+    }
+];


### PR DESCRIPTION
I am working on a larger app that has a mobile and desktop bundle all being served from 1 server. Because of that, instead of doing something like the following provided in the readme:

```js
// NOTE: Only the client bundle needs to be passed to `webpack-hot-middleware`.
app.use(webpackHotMiddleware(compiler.compilers.find(compiler => compiler.name === 'client')));
```

Mine looks more like:

```js
// Those are my 2 client bundles
const clientCompiler = new MultiCompiler(compiler.compilers.slice(0, 2));
app.use(webpackHotMiddleware(clientCompiler));
```

This means instead of having `clientStats` being a single object, I need an array of objects for both bundles. 

This change only gives an array for `clientStats` when providing multiple client bundles. Also since I figured one might want to differentiate between multiple bundles, I check that the compiler name starts with "client" or "server" to keep backwards compatibility. My setup has them named "client-mobile" and "client-desktop".