### PR TITLE
Performance improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ The name of the server entry point, defaults to 'main'.
 **serverRendererOptions** `object`
 Mixed in with `clientStats` & `serverStats` and passed to the `serverRenderer`.
 
+**webpackStatsHandler** `function`
+This gives you control over what options are passed to Webpack's [`toJson()`](https://webpack.js.org/api/node/#stats-tojson-options-) function. The default is `function(stats) { return stats.toJson() }`
+
 ### Example
 
 A simple example can be found in the [example](example) directory and a more real world example can be seen in the [60fram.es boilerplate](https://github.com/60frames/react-boilerplate).


### PR DESCRIPTION
Webpack `stats.toJson()` is an expensive call. I'm in the process of upgrading to Webpack 4 and noticed when stepping through the code, I'd run out of memory when the stats were being gathered for the client/server. This PR does 2 things.

- Updates the `getFilename` function to only get the `assets` data since it only needed the chunk names
- Allows the consumer to return their own stats JSON for each of the compilers passed to the middleware

An example use of this would be something like:

```js
app.use(webpackHotServerMiddleware(compiler, {
    webpackStatsHandler: (stats) => {
        return stats.toJson({
            all: false,
            chunkGroups: true,
            assets: true
        });
    }
}));
```